### PR TITLE
feature: Init base postgres minio redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,16 @@ HAIBAZO_BFF_MOCK_STORAGE = "s3"
 HAIBAZO_BFF_MOCK_S3_FOLDER = "./bff/st-a/haibazo-bff-mock-static"
 HAIBAZO_BFF_AWS_IAM_ACCESS_KEY = "your-access-key"
 HAIBAZO_BFF_AWS_IAM_SECRET_KEY = "your-secret-key"
+
+POSTGRES_USERNAME=user
+POSTGRES_PASSWORD=password
+POSTGRES_DATABASE=postgres_db
+
+# Redis configuration
+REDIS_PASSWORD=my_redis_password
+
+# MinIO configuration
+MINIO_ACCESS_KEY=minio
+MINIO_SECRET_KEY=minio_secret
+MINIO_URL=http://localhost:9090
+MINIO_BUCKET=demo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,17 @@
+version: '3'
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  cache:
+    driver: local
+  db-data:
+    driver: local
+  minio-data:
+    driver: local
+
 services:
   haibazo-bff-mock-webapi-development:
     image: hbzkhanhnk/haibazo-bff-mock-webapi:1.0.3
@@ -10,38 +24,99 @@ services:
       - "2380:8080"
     volumes:
       - ./haibazo-bff-mock-static:/app/haibazo-bff-mock-static
+      - ./haibazo-bff-mock-webapi/src/main/java:/app/src/main/java
     env_file:
       - path: ./.env.development
         required: false
+    networks:
+      - app-network
+    depends_on:
+      - db
+      - minio
+      - redis
 
-  haibazo-bff-mock-webapi-st-a:
-    image: hbzkhanhnk/haibazo-bff-mock-webapi:1.0.3
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: haibazo-bff-mock-webapi-runner
-    container_name: haibazo-bff-mock-webapi-st-a
-    ports:
-      - "2301:8080"
-    env_file:
-      - path: ./.env.st-a
-        required: false
-    restart: unless-stopped
-    volumes:
-      - ./haibazo-bff-mock-static-st-a:/app/haibazo-bff-mock-static
+  # haibazo-bff-mock-webapi-st-a:
+  #   image: hbzkhanhnk/haibazo-bff-mock-webapi:1.0.3
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile
+  #     target: haibazo-bff-mock-webapi-runner
+  #   container_name: haibazo-bff-mock-webapi-st-a
+  #   ports:
+  #     - "2301:8080"
+  #   env_file:
+  #     - path: ./.env.st-a
+  #       required: false
+  #   restart: unless-stopped
+  #   volumes:
+  #     - ./haibazo-bff-mock-static-st-a:/app/haibazo-bff-mock-static
+  #   networks:
+  #     - app-network
+  #   depends_on:
+  #     - db
+  #     - minio
+  #     - redis
 
-  haibazo-bff-mock-webapi-st-b:
-    image: hbzkhanhnk/haibazo-bff-mock-webapi:1.0.3
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: haibazo-bff-mock-webapi-runner
-    container_name: haibazo-bff-mock-webapi-st-b
+  # haibazo-bff-mock-webapi-st-b:
+  #   image: hbzkhanhnk/haibazo-bff-mock-webapi:1.0.3
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile
+  #     target: haibazo-bff-mock-webapi-runner
+  #   container_name: haibazo-bff-mock-webapi-st-b
+  #   ports:
+  #     - "2302:8080"
+  #   env_file:
+  #     - path: ./.env.st-b
+  #       required: false
+  #   restart: unless-stopped
+  #   volumes:
+  #     - ./haibazo-bff-mock-static-st-b:/app/haibazo-bff-mock-static
+  #   networks:
+  #     - app-network
+  #   depends_on:
+  #     - db
+  #     - minio
+  #     - redis
+
+  db:
+    image: postgres:15.1-alpine
+    container_name: postgres
+    networks:
+      - app-network
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=postgres_db
     ports:
-      - "2302:8080"
-    env_file:
-      - path: ./.env.st-b
-        required: false
-    restart: unless-stopped
+      - '5432:5432'
     volumes:
-      - ./haibazo-bff-mock-static-st-b:/app/haibazo-bff-mock-static
+      - ./src/main/resources/db-init:/docker-entrypoint-initdb.d
+      - db-data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7.2-rc-alpine
+    restart: always
+    container_name: redis
+    networks:
+      - app-network
+    ports:
+      - '6379:6379'
+    command: redis-server --save 20 1 --loglevel warning --requirepass my_redis_password
+    volumes:
+      - cache:/data
+
+  minio:
+    image: minio/minio:latest
+    container_name: minio
+    networks:
+      - app-network
+    environment:
+      - MINIO_ROOT_USER=minio
+      - MINIO_ROOT_PASSWORD=minio_secret
+    command: server ~/minio --console-address :9090
+    ports:
+      - '9090:9090'
+      - '9999:9999'
+    volumes:
+      - minio-data:/minio

--- a/haibazo-bff-mock-webapi/src/main/resources/application.properties.example
+++ b/haibazo-bff-mock-webapi/src/main/resources/application.properties.example
@@ -27,3 +27,19 @@ haibazo.bff.mock.s3.folder=${HAIBAZO_BFF_MOCK_S3_FOLDER:./bff/st-a}
 # cors
 haibazo.bff.cors.origins=${HAIBAZO_BFF_CORS_ORIGINS:*}
 haibazo.bff.cors.credentials=${HAIBAZO_BFF_CORS_CREDENTIALS:true}
+
+# PostgreSQL configuration
+spring.datasource.url=jdbc:postgresql://localhost:5432/${POSTGRES_DATABASE}
+spring.datasource.username=${POSTGRES_USERNAME}
+spring.datasource.password=${POSTGRES_PASSWORD}
+
+# Redis configuration
+spring.redis.host=localhost
+spring.redis.port=6379
+spring.redis.password=${REDIS_PASSWORD}
+
+# MinIO configuration
+minio.url=${MINIO_URL}
+minio.access-key=${MINIO_ACCESS_KEY}
+minio.secret-key=${MINIO_SECRET_KEY}
+minio.bucket=${MINIO_BUCKET}


### PR DESCRIPTION
# Create postgres, minio, redis services

### Inside of your project, you'll run the command:

```
docker-compose up --build
```

### Minio:
```
http://localhost:9090
```
<img width="1083" alt="image" src="https://github.com/user-attachments/assets/26ade5d7-7af7-4416-a461-a056abacd980" />

- `username: minio`
- `password: minio_secret`

#### Create bucket demo
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/11b53962-514c-406a-8606-21174de7f092" />

<img width="1080" alt="image" src="https://github.com/user-attachments/assets/0d8c42f6-ea53-40b2-a7c1-01cbf3a91b26" />


### Postgres:
#### Download tool to run postgres:
<img width="1097" alt="image" src="https://github.com/user-attachments/assets/4123dbc6-30d4-4151-b08a-a44bf3d2c6c5" />

#### Connect to postgres, example in table plus:
- `host`: 127.0.0.1, `user`: user, `password`: password, `database`: postgres_db
<img width="493" alt="image" src="https://github.com/user-attachments/assets/80a2c585-71a8-4ac6-8bb1-334d388fad36" />

### Redis
